### PR TITLE
Add configurable base urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ the GoDoc link above.
 ```go
 conf := func(s *synthetics.Client) {
 	s.APIKey = os.Getenv("NEWRELIC_API_KEY")
+
+	// SyntheticsBaseURL is optional.
+	// Default is https://synthetics.newrelic.com/synthetics/api/v3
+	s.SyntheticsBaseURL = os.Getenv("NEWRELIC_SYNTHETICS_API_URL")
 }
 client, _ := synthetics.NewClient(conf)
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 
 A [New Relic Synthetics](https://newrelic.com/synthetics) API client
 for Go. This package provides CRUD functionality for both Synthetics
-monitors and alert conditions. Detailed API docs can be found on
-the GoDoc link above.
+monitors, backed by the [New Relic Synthetics API](https://docs.newrelic.com/docs/apis/synthetics-rest-api), and Synthetics alert conditions, backed by the [New Relic V2 API](https://docs.newrelic.com/docs/apis/rest-api-v2).
+
+Detailed API docs for this client can be found on the GoDoc link above.
 
 ## Example
 
@@ -17,6 +18,10 @@ conf := func(s *synthetics.Client) {
 	// SyntheticsBaseURL is optional.
 	// Default is https://synthetics.newrelic.com/synthetics/api/v3
 	s.SyntheticsBaseURL = os.Getenv("NEWRELIC_SYNTHETICS_API_URL")
+
+	// V2BaseURL is optional.
+	// Default is https://api.newrelic.com/v2
+	s.V2BaseURL = os.Getenv("NEWRELIC_V2_API_URL")
 }
 client, _ := synthetics.NewClient(conf)
 

--- a/synthetics.go
+++ b/synthetics.go
@@ -31,7 +31,12 @@ const (
 	TypeScriptBrowser = "SCRIPT_BROWSER"
 
 	// SyntheticsBaseURL sets the base URL for the synthetics API.
+	// Default is https://synthetics.newrelic.com/synthetics/api/v3
 	SyntheticsBaseURL = "https://synthetics.newrelic.com/synthetics/api/v3"
+
+	// V2BaseURL sets the base URL for the V2 API.
+	// Default is https://api.newrelic.com/v2
+	V2BaseURL = "https://api.newrelic.com/v2"
 )
 
 var (
@@ -50,10 +55,11 @@ var (
 	ErrAlertConditionNotFound = errors.New("error: alert condition not found")
 )
 
-// Client is a client to New Relic Synthetics.
+// Client is a client to New Relic's Synthetics API and V2 API.
 type Client struct {
 	APIKey            string
 	SyntheticsBaseURL string
+	V2BaseURL         string
 	HTTPClient        HTTPClient
 
 	// The HTTP client that's actually used.
@@ -70,6 +76,10 @@ func NewClient(configs ...func(*Client)) (*Client, error) {
 
 	if client.SyntheticsBaseURL == "" {
 		client.SyntheticsBaseURL = SyntheticsBaseURL
+	}
+
+	if client.V2BaseURL == "" {
+		client.V2BaseURL = V2BaseURL
 	}
 
 	// Validate configuration
@@ -629,7 +639,7 @@ func (c *Client) CreateAlertCondition(policyID uint, args *CreateAlertConditionA
 		}
 		request, err := c.getRequest(
 			"POST",
-			fmt.Sprintf("https://api.newrelic.com/v2/alerts_synthetics_conditions/policies/%d.json", policyID),
+			fmt.Sprintf(c.V2BaseURL+"/alerts_synthetics_conditions/policies/%d.json", policyID),
 			requestBuf,
 		)
 		if err != nil {
@@ -686,7 +696,7 @@ func (c *Client) UpdateAlertCondition(alertConditionID uint, args *UpdateAlertCo
 		}
 		request, err := c.getRequest(
 			"PUT",
-			fmt.Sprintf("https://api.newrelic.com/v2/alerts_synthetics_conditions/%d.json", alertConditionID),
+			fmt.Sprintf(c.V2BaseURL+"/alerts_synthetics_conditions/%d.json", alertConditionID),
 			requestBuf,
 		)
 		if err != nil {
@@ -726,7 +736,7 @@ func (c *Client) DeleteAlertCondition(alertConditionID uint) error {
 	requestFunc := func() (*http.Request, error) {
 		request, err := c.getRequest(
 			"DELETE",
-			fmt.Sprintf("https://api.newrelic.com/v2/alerts_synthetics_conditions/%d.json", alertConditionID),
+			fmt.Sprintf(c.V2BaseURL+"/alerts_synthetics_conditions/%d.json", alertConditionID),
 			nil,
 		)
 		if err != nil {
@@ -758,7 +768,7 @@ func (c *Client) GetAlertCondition(policyID, alertConditionID uint) (*AlertCondi
 	requestFunc := func() (*http.Request, error) {
 		request, err := c.getRequest(
 			"GET",
-			fmt.Sprintf("https://api.newrelic.com/v2/alerts_synthetics_conditions.json?policy_id=%d", policyID),
+			fmt.Sprintf(c.V2BaseURL+"/alerts_synthetics_conditions.json?policy_id=%d", policyID),
 			nil,
 		)
 		if err != nil {


### PR DESCRIPTION
This PR adds configurable base URLs for the [New Relic Synthetics API](https://docs.newrelic.com/docs/apis/synthetics-rest-api) and the [New Relic REST v2 API](https://docs.newrelic.com/docs/apis/rest-api-v2).

This enables support for EU-based accounts and integration testing scenarios.
